### PR TITLE
Add hex and base64 endpoints for integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Fetch Hex encoded Data 📦
         uses: JamesIves/fetch-api-data-action@v2
         with:
-          endpoint: https://hexendpoint-1i6tdpio4m6h.runkit.sh/
+          endpoint: https://hexendpoint-nh0yqdi130h9.runkit.sh/
           save-location: fetch-api-data-custom-encoding
           save-name: todo1
           encoding: hex
@@ -60,7 +60,7 @@ jobs:
       - name: Fetch Base64 Data 📦
         uses: JamesIves/fetch-api-data-action@v2
         with:
-          endpoint: https://base64endpoint-prgyuqhv7685.runkit.sh/
+          endpoint: https://base64endpoint-83z1ttylbpmh.runkit.sh/
           save-location: fetch-api-data-custom-encoding
           save-name: todo2
           encoding: base64

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,13 +47,23 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Fetch Data 📦
+      - name: Fetch Hex encoded Data 📦
         uses: JamesIves/fetch-api-data-action@v2
         with:
-          endpoint: https://jsonplaceholder.typicode.com/todos/1
+          endpoint: https://hexendpoint-1i6tdpio4m6h.runkit.sh/
+          save-location: fetch-api-data-custom-encoding
+          save-name: todo1
+          encoding: hex
+          format: txt
+          retry: true
+
+      - name: Fetch Base64 Data 📦
+        uses: JamesIves/fetch-api-data-action@v2
+        with:
+          endpoint: https://base64endpoint-prgyuqhv7685.runkit.sh/
           save-location: fetch-api-data-custom-encoding
           save-name: todo2
-          encoding: hex
+          encoding: base64
           format: txt
           retry: true
 


### PR DESCRIPTION
## Description

Update Integration test from 610b20e1a4c25d2800ec4d8db4edc088777a0b4d to include endpoints with encoded data as per encoding to save

## Testing Instructions

The deployment to GitHub pages will be the utf-8 format of the encoded data

## Additional Notes

- Base64 endpoint used: https://base64endpoint-83z1ttylbpmh.runkit.sh/ which returns base64 encoded data `Hello - Base64 encoded`. See https://runkit.com/humble-barnacle001/base64endpoint

- Hex endpoint used: https://hexendpoint-nh0yqdi130h9.runkit.sh/ which returns hex encoded data `Hello from Hex Endpoint!`. See https://runkit.com/humble-barnacle001/hexendpoint
