### PR TITLE
Use jest/recommended ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,15 @@
 {
-  "plugins": ["jest", "@typescript-eslint"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:jest/recommended"
   ],
-  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 9,
-    "sourceType": "module",
     "project": "./tsconfig.lint.json"
   },
-  "globals": {
-    "fetch": true
-  },
   "env": {
-    "node": true,
-    "es6": true,
-    "jest/globals": true
+    "node": true
   },
   "rules": {
     "@typescript-eslint/ban-types": [

--- a/__tests__/fetch.test.ts
+++ b/__tests__/fetch.test.ts
@@ -20,7 +20,7 @@ describe('fetch', () => {
       expect(data).toEqual('{"data":"12345"}')
     })
 
-    it('should handle the triple bracket replacements ', async () => {
+    it('should handle the triple bracket replacements', async () => {
       nock('https://jives.dev/')
         .post('/', '{"bestCat":"montezuma"}')
         .reply(200, {
@@ -43,20 +43,18 @@ describe('fetch', () => {
     })
 
     it('should error if improperly formatted json is passed in', async () => {
-      try {
-        nock('https://jamesiv.es').get('/').reply(200)
+      nock('https://jamesiv.es').get('/').reply(200)
 
-        await retrieveData({
+      await expect(
+        retrieveData({
           debug: true,
           endpoint: 'https://example.com',
           configuration: '"{"method:"POST","body":{"bestCat":"{{{ cat }}}"}}"',
           auth: '{"cat: "montezuma"}'
         })
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          "There was an error fetching from the API: TypeError: Cannot read property 'cat' of null ❌"
-        )
-      }
+      ).rejects.toThrow(
+        "There was an error fetching from the API: TypeError: Cannot read property 'cat' of null ❌"
+      )
     })
 
     it('should error if the response is not ok', async () => {
@@ -64,8 +62,8 @@ describe('fetch', () => {
         a: 1
       })
 
-      try {
-        await retrieveData({
+      await expect(
+        retrieveData({
           debug: true,
           endpoint: 'https://jamesiv.es',
           configuration: JSON.stringify({
@@ -75,35 +73,31 @@ describe('fetch', () => {
             }
           })
         })
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'There was an error fetching from the API: Error: {"a":1} ❌'
-        )
-      }
+      ).rejects.toThrow(
+        'There was an error fetching from the API: Error: {"a":1} ❌'
+      )
     })
 
     it('should error if the response is not ok after several retrys', async () => {
       jest.setTimeout(1000000)
 
-      try {
-        nock('https://jives.dev').get('/').once().replyWithError({
-          message: 'This is catastrophic'
-        })
+      nock('https://jives.dev').get('/').once().replyWithError({
+        message: 'This is catastrophic'
+      })
 
-        nock('https://jives.dev').get('/').reply(200, {
-          data: '12345'
-        })
+      nock('https://jives.dev').get('/').reply(200, {
+        data: '12345'
+      })
 
-        await retrieveData({
+      await expect(
+        retrieveData({
           debug: true,
           endpoint: 'https://jives.dev',
           retry: true
         })
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'There was an error fetching from the API: FetchError: invalid json response body at https://jives.dev/ reason: Unexpected token < in JSON at position 0 ❌'
-        )
-      }
+      ).rejects.toThrow(
+        'There was an error fetching from the API: FetchError: invalid json response body at https://jives.dev/ reason: Unexpected token < in JSON at position 0 ❌'
+      )
     })
   })
 
@@ -149,19 +143,17 @@ describe('fetch', () => {
     })
 
     it('should fail if invalid encoding is used', async () => {
-      try {
-        await generateExport({
+      await expect(
+        generateExport({
           data: '68656C6C6F21',
           encoding: 'hexxxxx' as BufferEncoding,
           format: 'txt',
           saveName: 'hex-data',
           setOutput: true
         })
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          `There was an error generating the export file: TypeError [ERR_INVALID_OPT_VALUE_ENCODING]: The value "hexxxxx" is invalid for option "encoding" ❌`
-        )
-      }
+      ).rejects.toThrow(
+        `There was an error generating the export file: TypeError [ERR_INVALID_OPT_VALUE_ENCODING]: The value "hexxxxx" is invalid for option "encoding" ❌`
+      )
     })
   })
 })

--- a/__tests__/lib.test.ts
+++ b/__tests__/lib.test.ts
@@ -35,7 +35,7 @@ describe('lib', () => {
     })
     await run(action)
 
-    expect(exportVariable).toBeCalled()
+    expect(exportVariable).toHaveBeenCalled()
   })
 
   it('should run through the commands but not save output', async () => {
@@ -46,7 +46,7 @@ describe('lib', () => {
     })
     await run(action)
 
-    expect(exportVariable).toBeCalledTimes(0)
+    expect(exportVariable).toHaveBeenCalledTimes(0)
   })
 
   it('should throw an error if no endpoint is provided', async () => {
@@ -55,11 +55,8 @@ describe('lib', () => {
       endpoint: null
     })
 
-    try {
-      await run(action)
-    } catch (error) {
-      expect(setFailed).toBeCalled()
-    }
+    await expect(run(action)).rejects.toThrow()
+    expect(setFailed).toHaveBeenCalled()
   })
 
   it('should fetch data if a token endpoint is provided', async () => {
@@ -70,10 +67,7 @@ describe('lib', () => {
       tokenConfiguration: JSON.stringify({method: 'GET'})
     })
 
-    try {
-      await run(action)
-    } catch (error) {
-      expect(setFailed).toBeCalled()
-    }
+    await expect(run(action)).rejects.toThrow()
+    expect(setFailed).toHaveBeenCalled()
   })
 })

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "5.20.0",
     "eslint": "8.18.0",
     "eslint-config-prettier": "8.5.0",
-    "eslint-plugin-jest": "26.5.3",
+    "eslint-plugin-jest": "27.0.4",
     "eslint-plugin-prettier": "4.2.1",
     "jest": "27.5.1",
     "jest-circus": "27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,10 +1524,10 @@ eslint-config-prettier@8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
-eslint-plugin-jest@26.5.3:
-  version "26.5.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.5.3.tgz#a3ceeaf4a757878342b8b00eca92379b246e5505"
-  integrity sha512-sICclUqJQnR1bFRZGLN2jnSVsYOsmPYYnroGCIMVSvTS3y8XR3yjzy1EcTQmk6typ5pRgyIWzbjqxK6cZHEZuQ==
+eslint-plugin-jest@27.0.4:
+  version "27.0.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.0.4.tgz#ab9c7b3f48bfade4762c24c415a5d9bbc0174a61"
+  integrity sha512-BuvY78pHMpMJ6Cio7sKg6jrqEcnRYPUc4Nlihku4vKx3FjlmMINSX4vcYokZIe+8TKcyr1aI5Kq7vYwgJNdQSA==
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->
We have `eslint-plugin-jest` installed, but we don't have any of its rules configured. I enabled the `jest/recommended` config to help fix some bugs I noticed in the tests. Some tests are now failing due to bugs in the implementation that are surfaced by fixed tests.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->
Run Jest and ESLint

## Additional Notes

<!-- Anything else that will help us test the pull request. -->
Discovered in #727